### PR TITLE
Enable native AV1 VideoToolbox decoding on macOS

### DIFF
--- a/build-ffmpeg-macos.sh
+++ b/build-ffmpeg-macos.sh
@@ -8,7 +8,7 @@ git apply ../patches/ffmpeg_metal_vt.patch
 
 # Build FFmpeg
 mkdir ../build/FFmpeg/build_$1
-PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure --prefix=$PWD/../build/FFmpeg/build_$1 --extra-cflags="-mmacosx-version-min=$MACOS_MIN -arch $2 --target=$2-apple-macosx -I$VULKAN_SDK/include" --extra-ldflags="-mmacosx-version-min=$MACOS_MIN -arch $2" --cc=clang --arch=$2 --enable-cross-compile --install-name-dir=@loader_path/../Frameworks --enable-pic --enable-lto --fatal-warnings --enable-shared --disable-static --disable-all --disable-autodetect --enable-avcodec --enable-avformat --enable-swscale --enable-vulkan --enable-decoder=h264 --enable-decoder=hevc --enable-videotoolbox --enable-hwaccel=h264_videotoolbox --enable-hwaccel=hevc_videotoolbox --enable-hwaccel=av1_videotoolbox --enable-libdav1d --enable-decoder=libdav1d
+PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure --prefix=$PWD/../build/FFmpeg/build_$1 --extra-cflags="-mmacosx-version-min=$MACOS_MIN -arch $2 --target=$2-apple-macosx -I$VULKAN_SDK/include" --extra-ldflags="-mmacosx-version-min=$MACOS_MIN -arch $2" --cc=clang --arch=$2 --enable-cross-compile --install-name-dir=@loader_path/../Frameworks --enable-pic --enable-lto --fatal-warnings --enable-shared --disable-static --disable-all --disable-autodetect --enable-avcodec --enable-avformat --enable-swscale --enable-vulkan --enable-decoder=h264 --enable-decoder=hevc --enable-decoder=av1 --enable-videotoolbox --enable-hwaccel=h264_videotoolbox --enable-hwaccel=hevc_videotoolbox --enable-hwaccel=av1_videotoolbox --enable-libdav1d --enable-decoder=libdav1d
 make -j$(sysctl -n hw.ncpu)
 make install
 


### PR DESCRIPTION
## What changed

Enable FFmpeg's native AV1 decoder in the macOS dependency build.

The build already enabled `av1_videotoolbox`, but only built the `libdav1d`
decoder. FFmpeg exposes the VideoToolbox hardware configuration through its
native `av1` decoder, so Moonlight could not discover AV1 hardware decoding and
fell back to HEVC when hardware decoding was required.

`libdav1d` remains enabled as the software fallback.

Fixes the dependency-side regression still reported in
moonlight-stream/moonlight-qt#1125.

## Validation

- Built the pinned FFmpeg 8.1 commit on Apple Silicon.
- Verified configure reports:
  - decoders: `av1`, `libdav1d`
  - hwaccel: `av1_videotoolbox`
- Verified `avcodec_get_hw_config()` exposes `videotoolbox_vld` for the native
  AV1 decoder while `libdav1d` remains available.
- Built current Moonlight Qt master against the resulting dependency.
- Streamed AV1 Main10 HDR at 3024×1964, 60 FPS on an M4 Pro with hardware
  decoding forced. Moonlight negotiated AV1 Main10 (`format 0x2000`) and FFmpeg
  selected `videotoolbox_vld` successfully.
